### PR TITLE
Solidus 2.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,12 +3,10 @@ cache: bundler
 language: ruby
 env:
   matrix:
-    - SOLIDUS_BRANCH=v1.3 DB=mysql
-    - SOLIDUS_BRANCH=v1.3 DB=postgres
-    - SOLIDUS_BRANCH=v1.4 DB=mysql
-    - SOLIDUS_BRANCH=v1.4 DB=postgres
-    - SOLIDUS_BRANCH=v2.0 DB=mysql
-    - SOLIDUS_BRANCH=v2.0 DB=postgres
+    - SOLIDUS_BRANCH=v2.1 DB=mysql
+    - SOLIDUS_BRANCH=v2.1 DB=postgres
+    - SOLIDUS_BRANCH=master DB=mysql
+    - SOLIDUS_BRANCH=master DB=postgres
 script:
   - bundle exec rake test_app
   - bundle exec rspec

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,4 +13,4 @@ script:
   - bundle exec rake test_app
   - bundle exec rspec
 rvm:
-  - 2.1.8
+  - 2.3.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,10 @@ env:
   matrix:
     - SOLIDUS_BRANCH=v1.3 DB=mysql
     - SOLIDUS_BRANCH=v1.3 DB=postgres
-    - SOLIDUS_BRANCH=master DB=mysql
-    - SOLIDUS_BRANCH=master DB=postgres
+    - SOLIDUS_BRANCH=v1.4 DB=mysql
+    - SOLIDUS_BRANCH=v1.4 DB=postgres
+    - SOLIDUS_BRANCH=v2.0 DB=mysql
+    - SOLIDUS_BRANCH=v2.0 DB=postgres
 script:
   - bundle exec rake test_app
   - bundle exec rspec

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source "https://rubygems.org"
 
-branch = ENV.fetch('SOLIDUS_BRANCH', 'v1.4')
+branch = ENV.fetch('SOLIDUS_BRANCH', 'master')
 gem "solidus", github: "solidusio/solidus", branch: branch
 gem "solidus_auth_devise", "~> 1.0"
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source "https://rubygems.org"
 
-branch = ENV.fetch('SOLIDUS_BRANCH', 'master')
+branch = ENV.fetch('SOLIDUS_BRANCH', 'v1.4')
 gem "solidus", github: "solidusio/solidus", branch: branch
 gem "solidus_auth_devise", "~> 1.0"
 

--- a/app/models/spree/order_contents_decorator.rb
+++ b/app/models/spree/order_contents_decorator.rb
@@ -1,26 +1,27 @@
-Spree::OrderContents.class_eval do
-  def add_with_avatax(*args)
-    add_without_avatax(*args).tap do
-      SpreeAvatax::SalesShared.reset_tax_attributes(order)
+module Solidus
+  module Avatax
+    module OrderContentsDecorator
+      def add(*args)
+        super.tap do
+          SpreeAvatax::SalesShared.reset_tax_attributes(order)
+        end
+      end
+
+      def remove(*args)
+        super.tap do
+          SpreeAvatax::SalesShared.reset_tax_attributes(order)
+        end
+      end
+
+      def update_cart(params)
+        if super
+          SpreeAvatax::SalesShared.reset_tax_attributes(order)
+          true
+        else
+          false
+        end
+      end
     end
   end
-
-  def remove_with_avatax(*args)
-    remove_without_avatax(*args).tap do
-      SpreeAvatax::SalesShared.reset_tax_attributes(order)
-    end
-  end
-
-  def update_cart_with_avatax(params)
-    if update_cart_without_avatax(params)
-      SpreeAvatax::SalesShared.reset_tax_attributes(order)
-      true
-    else
-      false
-    end
-  end
-
-  alias_method_chain :update_cart, :avatax
-  alias_method_chain :add, :avatax
-  alias_method_chain :remove, :avatax
 end
+Spree::OrderContents.send(:prepend, Solidus::Avatax::OrderContentsDecorator)

--- a/app/models/spree/order_decorator.rb
+++ b/app/models/spree/order_decorator.rb
@@ -34,7 +34,7 @@ Spree::Order.class_eval do
     #       recursion since it will cause another "after_save" to be called with the dirty attributes
     #       in the same state. Instead just move the order out of the "confirm" state so that it
     #       will have to go through tax calculations again.
-    if ship_address_id_changed? && confirm?
+    if saved_change_to_ship_address_id? && confirm?
       Rails.logger.info "[avatax] order address change detected for order #{number} while in confirm state. resetting order state to 'payment'."
       update_columns(state: 'payment', updated_at: Time.now)
     end

--- a/app/models/spree/promotion_handler/coupon_decorator.rb
+++ b/app/models/spree/promotion_handler/coupon_decorator.rb
@@ -1,11 +1,15 @@
-Spree::PromotionHandler::Coupon.class_eval do
-  def apply_with_avatax
-    apply_without_avatax.tap do
-      if successful?
-        SpreeAvatax::SalesShared.reset_tax_attributes(order)
+module Solidus
+  module Avatax
+    module PromotionHandler
+      def apply
+        super.tap do
+          if successful?
+            SpreeAvatax::SalesShared.reset_tax_attributes(order)
+          end
+        end
       end
     end
   end
-
-  alias_method_chain :apply, :avatax
 end
+
+Spree::PromotionHandler::Coupon.send(:prepend, Solidus::Avatax::PromotionHandler)

--- a/app/models/spree/tax/order_adjuster_decorator.rb
+++ b/app/models/spree/tax/order_adjuster_decorator.rb
@@ -1,9 +1,9 @@
-Spree::Tax::OrderAdjuster.class_eval do
-  def adjust_with_avatax!
+module Solidus::Avatax::OrderAdjuster
+  def adjust!
     # do nothing. we hook in in our own ways.
     # TODO: See if we can make OrderAdjuster pluggable and workable for what we
     # need to do.
   end
-
-  alias_method_chain :adjust!, :avatax
 end
+
+Spree::Tax::OrderAdjuster.send(:prepend, Solidus::Avatax::OrderAdjuster)

--- a/app/models/spree_avatax/sales_shared.rb
+++ b/app/models/spree_avatax/sales_shared.rb
@@ -43,7 +43,6 @@ module SpreeAvatax::SalesShared
           finalized:  true, # this tells spree not to automatically recalculate avatax tax adjustments
         })
 
-        Spree::ItemAdjustments.new(record).update
         record.save!
       end
 
@@ -119,9 +118,6 @@ module SpreeAvatax::SalesShared
           adjustment_total: 0,
           included_tax_total: 0,
         })
-
-        Spree::ItemAdjustments.new(taxable_record).update
-        taxable_record.save!
       end
 
       order.update_attributes!({

--- a/db/migrate/20140122165618_add_avatax_response_at_to_orders.rb
+++ b/db/migrate/20140122165618_add_avatax_response_at_to_orders.rb
@@ -1,4 +1,4 @@
-class AddAvataxResponseAtToOrders < ActiveRecord::Migration
+class AddAvataxResponseAtToOrders < ActiveRecord::Migration[5.1]
   def change
     add_column :spree_orders, :avatax_response_at, :datetime
   end

--- a/db/migrate/20140214153139_add_avatax_invoice_at_to_orders.rb
+++ b/db/migrate/20140214153139_add_avatax_invoice_at_to_orders.rb
@@ -1,5 +1,5 @@
-class AddAvataxInvoiceAtToOrders < ActiveRecord::Migration
-  def change 
+class AddAvataxInvoiceAtToOrders < ActiveRecord::Migration[5.1]
+  def change
     add_column :spree_orders, :avatax_invoice_at, :datetime
   end
 end

--- a/db/migrate/20140617222244_close_all_tax_adjustments.rb
+++ b/db/migrate/20140617222244_close_all_tax_adjustments.rb
@@ -1,4 +1,4 @@
-class CloseAllTaxAdjustments < ActiveRecord::Migration
+class CloseAllTaxAdjustments < ActiveRecord::Migration[5.1]
   def up
     Spree::Adjustment.tax.update_all(finalized: true)
   end

--- a/db/migrate/20140701144237_update_avatax_calculator_type.rb
+++ b/db/migrate/20140701144237_update_avatax_calculator_type.rb
@@ -1,4 +1,4 @@
-class UpdateAvataxCalculatorType < ActiveRecord::Migration
+class UpdateAvataxCalculatorType < ActiveRecord::Migration[5.1]
   def up
     Spree::Calculator.where(
       type: "SpreeAvatax::Calculator"

--- a/db/migrate/20140801132302_create_spree_avatax_return_invoices.rb
+++ b/db/migrate/20140801132302_create_spree_avatax_return_invoices.rb
@@ -1,4 +1,4 @@
-class CreateSpreeAvataxReturnInvoices < ActiveRecord::Migration
+class CreateSpreeAvataxReturnInvoices < ActiveRecord::Migration[5.1]
   def change
     create_table :spree_avatax_return_invoices do |t|
       t.integer :reimbursement_id

--- a/db/migrate/20140903135132_create_spree_avatax_sales_orders.rb
+++ b/db/migrate/20140903135132_create_spree_avatax_sales_orders.rb
@@ -1,4 +1,4 @@
-class CreateSpreeAvataxSalesOrders < ActiveRecord::Migration
+class CreateSpreeAvataxSalesOrders < ActiveRecord::Migration[5.1]
   def change
     create_table :spree_avatax_sales_orders do |t|
       t.integer :order_id,             null: false

--- a/db/migrate/20140903135357_create_spree_avatax_sales_invoices.rb
+++ b/db/migrate/20140903135357_create_spree_avatax_sales_invoices.rb
@@ -1,4 +1,4 @@
-class CreateSpreeAvataxSalesInvoices < ActiveRecord::Migration
+class CreateSpreeAvataxSalesInvoices < ActiveRecord::Migration[5.1]
   def change
     create_table :spree_avatax_sales_invoices do |t|
       t.integer  :order_id,             null: false

--- a/db/migrate/20140904171341_generate_uncommitted_sales_invoices.rb
+++ b/db/migrate/20140904171341_generate_uncommitted_sales_invoices.rb
@@ -1,4 +1,4 @@
-class GenerateUncommittedSalesInvoices < ActiveRecord::Migration
+class GenerateUncommittedSalesInvoices < ActiveRecord::Migration[5.1]
   def up
     scope = Spree::Order.
       where(state: 'confirm').

--- a/db/migrate/20140911214414_add_transaction_id_to_sales_orders_and_sales_invoices.rb
+++ b/db/migrate/20140911214414_add_transaction_id_to_sales_orders_and_sales_invoices.rb
@@ -1,4 +1,4 @@
-class AddTransactionIdToSalesOrdersAndSalesInvoices < ActiveRecord::Migration
+class AddTransactionIdToSalesOrdersAndSalesInvoices < ActiveRecord::Migration[5.1]
   def change
     add_column :spree_avatax_sales_orders, :transaction_id, :string
     add_column :spree_avatax_sales_invoices, :transaction_id, :string

--- a/db/migrate/20140911215422_add_canceled_at_and_cancel_transaction_id_to_sales_invoices.rb
+++ b/db/migrate/20140911215422_add_canceled_at_and_cancel_transaction_id_to_sales_invoices.rb
@@ -1,4 +1,4 @@
-class AddCanceledAtAndCancelTransactionIdToSalesInvoices < ActiveRecord::Migration
+class AddCanceledAtAndCancelTransactionIdToSalesInvoices < ActiveRecord::Migration[5.1]
   def change
     add_column :spree_avatax_sales_invoices, :canceled_at, :datetime
     add_column :spree_avatax_sales_invoices, :cancel_transaction_id, :string

--- a/db/migrate/20150427154942_create_spree_avatax_short_ship_return_invoices.rb
+++ b/db/migrate/20150427154942_create_spree_avatax_short_ship_return_invoices.rb
@@ -1,4 +1,4 @@
-class CreateSpreeAvataxShortShipReturnInvoices < ActiveRecord::Migration
+class CreateSpreeAvataxShortShipReturnInvoices < ActiveRecord::Migration[5.1]
   def change
     create_table :spree_avatax_short_ship_return_invoices do |t|
       t.boolean :committed, null: false

--- a/db/migrate/20150427154942_create_spree_avatax_short_ship_return_invoices.rb
+++ b/db/migrate/20150427154942_create_spree_avatax_short_ship_return_invoices.rb
@@ -10,24 +10,18 @@ class CreateSpreeAvataxShortShipReturnInvoices < ActiveRecord::Migration[5.1]
     end
 
     create_table :spree_avatax_short_ship_return_invoice_inventory_units do |t|
-      t.references :short_ship_return_invoice, null: false
-      t.references :inventory_unit, null: false
+      t.references :short_ship_return_invoice,
+                   index: {
+                     name: 'index_spree_avatax_short_ships_on_invoice_id'
+                   },
+                   null: false
+      t.references :inventory_unit,
+                   index: { name: 'index_spree_avatax_short_ships_on_unit_id' },
+                   null: false
     end
 
     # The default index names for these are too long for sqlite/mysql/postgres
 
-    add_index(
-      :spree_avatax_short_ship_return_invoice_inventory_units,
-      :short_ship_return_invoice_id,
-      unique: true,
-      name: 'index_spree_avatax_short_ships_on_invoice_id',
-    )
-    add_index(
-      :spree_avatax_short_ship_return_invoice_inventory_units,
-      :inventory_unit_id,
-      unique: true,
-      name: 'index_spree_avatax_short_ships_on_unit_id',
-    )
     add_index(
       :spree_avatax_short_ship_return_invoices,
       :doc_id,

--- a/db/migrate/20150518172627_fix_avatax_short_ship_index.rb
+++ b/db/migrate/20150518172627_fix_avatax_short_ship_index.rb
@@ -1,4 +1,4 @@
-class FixAvataxShortShipIndex < ActiveRecord::Migration
+class FixAvataxShortShipIndex < ActiveRecord::Migration[5.1]
   def up
     remove_index(
       :spree_avatax_short_ship_return_invoice_inventory_units,

--- a/db/migrate/20151130195450_add_spree_avatax_configs.rb
+++ b/db/migrate/20151130195450_add_spree_avatax_configs.rb
@@ -1,4 +1,4 @@
-class AddSpreeAvataxConfigs < ActiveRecord::Migration
+class AddSpreeAvataxConfigs < ActiveRecord::Migration[5.1]
   def change
     create_table 'spree_avatax_configs' do |t|
       t.boolean 'enabled', null: false

--- a/solidus_avatax.gemspec
+++ b/solidus_avatax.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.require_path = "lib"
   s.requirements << "none"
 
-  s.add_dependency "solidus_core", ">= 1.3.0", "< 2.1"
+  s.add_dependency "solidus_core", ">= 2.1.0.rc1", "< 3"
   s.add_dependency "hashie",      "~> 2.l.5"
   s.add_dependency "multi_json"
   s.add_dependency "Avatax_TaxService", "~> 2.0.0"

--- a/solidus_avatax.gemspec
+++ b/solidus_avatax.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.require_path = "lib"
   s.requirements << "none"
 
-  s.add_dependency "solidus_core", ">= 1.3.0.alpha", "< 1.4"
+  s.add_dependency "solidus_core", ">= 1.3.0", "< 2.1"
   s.add_dependency "hashie",      "~> 2.l.5"
   s.add_dependency "multi_json"
   s.add_dependency "Avatax_TaxService", "~> 2.0.0"

--- a/solidus_avatax.gemspec
+++ b/solidus_avatax.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.require_path = "lib"
   s.requirements << "none"
 
-  s.add_dependency "solidus_core", ">= 2.1.0.rc1", "< 3"
+  s.add_dependency "solidus_core", ">= 2.3", "< 3"
   s.add_dependency "hashie",      "~> 2.l.5"
   s.add_dependency "multi_json"
   s.add_dependency "Avatax_TaxService", "~> 2.0.0"

--- a/spec/models/spree/order_contents_spec.rb
+++ b/spec/models/spree/order_contents_spec.rb
@@ -7,7 +7,7 @@ describe Spree::OrderContents do
   describe 'add_with_avatax' do
     let(:variant) { create :variant }
 
-    subject { order_contents.add_with_avatax(variant) }
+    subject { order_contents.add(variant) }
 
     it 'clears tax' do
       expect(SpreeAvatax::SalesShared).to receive(:reset_tax_attributes).with(order)
@@ -16,7 +16,7 @@ describe Spree::OrderContents do
   end
 
   describe 'remove_with_avatax' do
-    subject { order_contents.remove_with_avatax(order.line_items.first.variant) }
+    subject { order_contents.remove(order.line_items.first.variant) }
 
     it 'recomputes tax' do
       expect(SpreeAvatax::SalesShared).to receive(:reset_tax_attributes).with(order)
@@ -25,7 +25,7 @@ describe Spree::OrderContents do
   end
 
   describe 'update_cart_with_avatax' do
-    subject { order_contents.update_cart_with_avatax({}) }
+    subject { order_contents.update_cart({}) }
 
     it 'recomputes tax' do
       expect(SpreeAvatax::SalesShared).to receive(:reset_tax_attributes).with(order)

--- a/spec/models/spree/shipping_rate_spec.rb
+++ b/spec/models/spree/shipping_rate_spec.rb
@@ -1,19 +1,28 @@
 require 'spec_helper'
 
 describe Spree::ShippingRate do
+  let!(:tax_rate) do
+    rate = Spree::TaxRate.first
+    rate.zone.countries << shipment.order.ship_address.country
+    rate
+  end
+
   let(:shipping_rate) do
     shipment.shipping_rates.create!({
-      tax_rate:        Spree::TaxRate.first,
       shipping_method: shipping_method,
       cost:            10.00,
-      selected:        true,
+      selected:        true
     })
   end
 
   let(:shipment) { create(:shipment) }
-  let(:shipping_method) { create(:shipping_method) }
+  let(:shipping_method) { create(:shipping_method, tax_category: tax_rate.tax_category) }
+
+  before do
+    Spree::Config.shipping_rate_taxer_class.new.tax(shipping_rate)
+  end
 
   it 'calculates shipping rate taxes as 0' do
-    expect(shipping_rate.calculate_tax_amount).to eq 0
+    expect(shipping_rate.taxes.first.amount).to eq 0
   end
 end


### PR DESCRIPTION
Update to solidus 2.3

This update includes changes made on rails 5.1 basis:
- Specify rails version for which the migration was written for(5.1)
- `alias_method_chain` is gone and it does not exists on rails 5.1
- When first imported, [this migration ](https://github.com/nebulab/solidus_avatax/blob/solidus-2.1/db/migrate/20150427154942_create_spree_avatax_short_ship_return_invoices.rb#L13) is breaking the rake task because of the too long index. This pr fix the migration adding a shorter index name on table creation